### PR TITLE
Type to Array.includes

### DIFF
--- a/schemas/transaction-schema.js
+++ b/schemas/transaction-schema.js
@@ -21,13 +21,15 @@ function validateTransactionSchema(transaction, maxSpendableDigits, networkSymbo
   let { type } = transaction;
 
   if (
-    type !== 'transfer' &&
-    type !== 'vote' &&
-    type !== 'unvote' &&
-    type !== 'registerSigDetails' &&
-    type !== 'registerMultisigDetails' &&
-    type !== 'registerForgingDetails' &&
-    type !== 'registerMultisigWallet'
+    [
+      'transfer',
+      'vote',
+      'unvote',
+      'registerSigDetails',
+      'registerMultisigDetails',
+      'registerForgingDetails',
+      'registerMultisigWallet',
+    ].includes(type)
   ) {
     throw new Error(
       'Transaction type must be a string which refers to one of the supported transaction types'


### PR DESCRIPTION
@sacOO7 After some heavy searching and testing benchmarks I found out when you have this amount of comparisons it's better to use `Array.includes()` on the type. It's can be up to 2.5% faster. Sometimes test are almost equal but `Array.includes` prevails with more operations almost every time. If the conditional had only one comparison, it wouldn't be a good practice. Tests show that in that case it's slower.

![image](https://user-images.githubusercontent.com/14275291/107956748-60786f00-6f7e-11eb-909c-ac967e1742c1.png)

[Link to performance test](https://jsbench.me/27kl6n4ump/1)
[Link to performance test when only one](https://jsbench.me/27kl6n4ump/2)